### PR TITLE
Add support for Regexp type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can find more examples of using `flagit` [here](./examples).
   - `[]uint`, `[]uint8`, `[]uint16`, `[]uint32`, `[]uint64`
   - `time.Duration`, `[]time.Duration`
   - `url.URL`, `[]url.URL`
+  - `regexp.Regexp`, `[]regexp.Regexp`
 
 Nested structs are also supported. For a nested struct field, it should also be tagged with `flag:""` or `flag:"prefix"`.
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,1 +1,68 @@
 package flagit_test
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/moorara/flagit"
+)
+
+func ExamplePopulate() {
+	// spec is a struct for mapping its fields to command-line flags.
+	spec := struct {
+		// Flag fields
+		Verbose bool `flag:"verbose"`
+
+		// Nested fields
+		Options struct {
+			Port     uint16 `flag:"port"`
+			LogLevel string `flag:"log-level"`
+		}
+
+		// Nested fields with prefix
+		Config struct {
+			Timeout   time.Duration `flag:"timeout"`
+			Endpoints []url.URL     `flag:"endpoints"`
+		} `flag:"config-"`
+	}{}
+
+	if err := flagit.Populate(&spec, false); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", spec)
+}
+
+func ExampleRegisterFlags() {
+	// spec is a struct for mapping its fields to command-line flags.
+	spec := struct {
+		// Flag fields
+		Verbose bool `flag:"verbose,enable verbose logs"`
+
+		// Nested fields
+		Options struct {
+			Port     uint16 `flag:"port,the port number (1024-65535)"`
+			LogLevel string `flag:"log-level,the logging level (debug|info|warn|error)"`
+		}
+
+		// Nested fields with prefix
+		Config struct {
+			Timeout   time.Duration `flag:"timeout,the request timeout"`
+			Endpoints []url.URL     `flag:"endpoints,the replica endpoints"`
+		} `flag:"config-"`
+	}{}
+
+	fs := flag.NewFlagSet("app", flag.ContinueOnError)
+	if err := flagit.RegisterFlags(fs, &spec, false); err != nil {
+		panic(err)
+	}
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", spec)
+}

--- a/flagit.go
+++ b/flagit.go
@@ -75,7 +75,8 @@ func validateStruct(s interface{}) (reflect.Value, error) {
 }
 
 func isStructSupported(t reflect.Type) bool {
-	return (t.PkgPath() == "net/url" && t.Name() == "URL")
+	return (t.PkgPath() == "net/url" && t.Name() == "URL") ||
+		(t.PkgPath() == "regexp" && t.Name() == "Regexp")
 }
 
 func isNestedStruct(t reflect.Type) bool {
@@ -201,7 +202,7 @@ func setFieldValue(f fieldInfo, val string) (bool, error) {
 		case reflect.Uint64:
 			return setUint64Slice(f.value, vals)
 		case reflect.Struct:
-			return setURLSlice(f.value, vals)
+			return setStructSlice(f.value, vals)
 		}
 	}
 


### PR DESCRIPTION
## Description

  - [x] Ad support for `regexp.Regexp` type

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
